### PR TITLE
 🐛 Bug 修复:修复Markdown行内公式渲染问题

### DIFF
--- a/src/preview/ProblemPreviewView.ts
+++ b/src/preview/ProblemPreviewView.ts
@@ -160,13 +160,22 @@ class ProblemPreviewView implements Disposable {
     private getHtmlHead() {
         let html = `
             <meta http-equiv="Content-Security-Policy"
-                content = "default-src https://cdn.acwing.com 'unsafe-inline' 'none' ; 
-                img-src ${ this.panel?.webview.cspSource } https://cdn.acwing.com  https:; 
-                script-src ${ this.panel?.webview.cspSource } https://cdn.acwing.com 'unsafe-inline';
+                content = "default-src 'none';
+                img-src ${ this.panel?.webview.cspSource } https://cdn.acwing.com https:;
+                script-src ${ this.panel?.webview.cspSource } https://cdn.acwing.com https://cdnjs.cloudflare.com 'unsafe-inline' 'unsafe-eval';
                 style-src ${ this.panel?.webview.cspSource } https://cdn.acwing.com 'unsafe-inline';"
             />
             <link rel="stylesheet" href="${this.getResWebUri('acwing.css')}">
             <link rel="stylesheet" href="${this.getResWebUri('primer.css')}">
+            <style>
+                /* MathJax SVG 输出:文字颜色跟随主题 */
+                .MathJax_SVG svg text,
+                svg.MathJax_SVG text {
+                    fill: currentColor !important;
+                }
+                /* 隐藏的 MathJax 元素 */
+                #MathJax_SVG_Hidden { display: none !important; }
+            </style>
         `
         return html;
     }
@@ -248,22 +257,26 @@ class ProblemPreviewView implements Disposable {
 
     private getHtmlScript() {
         let html = `
-            <button id="solve">Code Now</button>                
-            <script type="text/javascript" src="https://cdn.acwing.com/static/MathJax-2.6-latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
-            <script type="text/x-mathjax-config;executed=true">
-                MathJax.Hub.Config({
-                    tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]},
-                    showMathMenu: false,
-                });
-            </script>
             <script>
-                console.log("MathJax.Hub.Config");
-                MathJax.Hub.Config({
-                    tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]},
+                window.MathJax = {
+                    tex2jax: {
+                        inlineMath: [['$','$'], ['\\(','\\)']],
+                        processEscapes: true
+                    },
                     showMathMenu: false,
-                });
-                //MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
+                    TeX: {
+                        extensions: ["AMSmath.js","AMSsymbols.js","noErrors.js","noUndefined.js"]
+                    },
+                    // SVG 输出模式:公式颜色天然继承 CSS,不会出现白→黑闪烁
+                    "HTML-CSS": { preferredFont: "TeX" },
+                    SVG: { font: "TeX" },
+                    // onLoad: MathJax 完全加载后触发
+                    onLoad: function() {
+                        MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
+                    }
+                };
             </script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-AMS-MML_SVG"></script>
             <script>
                 const vscode = acquireVsCodeApi();
                 const button = document.getElementById('solve');
@@ -313,6 +326,10 @@ class ProblemPreviewView implements Disposable {
             case "reloadProblem": {
                 console.log('reloadProblem()');
                 await this.showWebviewInternal();
+                break;
+            }
+            case "debug": {
+                console.log((message as any).text || JSON.stringify(message));
                 break;
             }
         }

--- a/src/preview/ProblemPreviewView.ts
+++ b/src/preview/ProblemPreviewView.ts
@@ -277,6 +277,7 @@ class ProblemPreviewView implements Disposable {
                 };
             </script>
             <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-AMS-MML_SVG"></script>
+            <button id="solve">Code Now</button>
             <script>
                 const vscode = acquireVsCodeApi();
                 const button = document.getElementById('solve');


### PR DESCRIPTION
# 插件修复说明：行内数学公式渲染失效

非常有用的插件,感谢大佬的贡献😘

### 问题
题目预览中，`$...$` 包裹的行内数学公式无法渲染，显示为原始文本。

![7ff48789-7334-4d3d-bfba-88a4777eb149.png](https://tk-pichost-1325224430.cos.ap-chengdu.myqcloud.com/blog/7ff48789-7334-4d3d-bfba-88a4777eb149.png)

### 原因分析
在 `ProblemPreviewView.ts` 中发现以下两个核心问题：

1. **CSP 策略限制**：Content Security Policy (CSP) 缺少 `'unsafe-eval'`。由于 MathJax 2 内部使用 `eval()` 进行公式渲染，`script-src` 中缺失该指令导致 MathJax 被浏览器静默拦截。
2. **MathJax 加载时序错误**：配置脚本和 `Hub.Queue(["Typeset"])` 在 MathJax 资源尚未完全加载完成时便触发执行，导致渲染逻辑失效。
### 修复方案
- **更新 CSP 策略**：添加 `'unsafe-eval'` 支持，并配置 CDN 备选源。
- **优化加载机制**：改用 `window.MathJax` 全局对象配合 `onLoad` 回调函数（遵循官方推荐的异步加载模式）。
- **优化输出模式**：将渲染模式切换为 **SVG 输出**，确保公式颜色能自动跟随 VS Code 主题变化。
### 改动文件
- `src/preview/ProblemPreviewView.ts`

### 修改后效果
![1779415513070.png](https://tk-pichost-1325224430.cos.ap-chengdu.myqcloud.com/blog/1779415513070.png)
